### PR TITLE
Polish WebGPU scaffold demo and preview entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -162,6 +162,26 @@ new Convas(document.querySelector('#app') as HTMLCanvasElement, { config: { rend
 
 ---
 
+## Getting Started (This Repo)
+
+```bash
+npm install
+npm run dev
+```
+
+Open the printed local URL to see the staged scene, dashboard, and post-processing stack. Adjust renderer exposure, light intensities, and PostFX parameters live from the glassmorphism dashboard.
+
+### Production preview
+
+```bash
+npm run build
+npm run preview
+```
+
+The preview build serves the same demo scene as `npm run dev`, showcasing the glass sculpture, animated halo particles, and dashboard controls (exposure, lighting, bloom/DOF plus the new “Demo Scene → Animate” toggle).
+
+---
+
 ## 10) Quality, Performance & Self‑Checks
 
 * **Budgets:** main thread < 4 ms, GPU < 12 ms on mid‑tier dGPU (1080p), 60 FPS target.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebGPU+TSL Scaffold Demo</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+        background: radial-gradient(circle at top, #111420 0%, #06070c 55%, #030308 100%);
+        color: #f1f3ff;
+      }
+      body {
+        display: flex;
+        align-items: stretch;
+        justify-content: stretch;
+      }
+      #app {
+        flex: 1;
+        display: block;
+        width: 100%;
+        height: 100%;
+        outline: none;
+      }
+      .hud {
+        position: fixed;
+        left: 50%;
+        bottom: 32px;
+        transform: translateX(-50%);
+        background: rgba(10, 12, 18, 0.72);
+        padding: 12px 18px;
+        border-radius: 999px;
+        box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+        backdrop-filter: blur(16px) saturate(140%);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        font-size: 13px;
+        line-height: 1.45;
+        letter-spacing: 0.02em;
+        pointer-events: none;
+        text-align: center;
+        color: rgba(230, 232, 239, 0.85);
+      }
+      a {
+        color: inherit;
+      }
+      @media (max-width: 640px) {
+        .hud {
+          width: min(92vw, 480px);
+          font-size: 12px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <canvas id="app" aria-label="Three.js WebGPU demo"></canvas>
+    <div class="hud">
+      Orbit with the mouse or touch, tweak lighting in the dashboard, and toggle animation via “Demo Scene → Animate”.
+    </div>
+    <noscript>
+      <div class="hud">Enable JavaScript to view the WebGPU+TSL scaffold demo.</div>
+    </noscript>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1060 @@
+{
+  "name": "universal-webgpu-tsl-scaffold",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "universal-webgpu-tsl-scaffold",
+      "version": "0.1.0",
+      "dependencies": {
+        "three": "^0.180.0",
+        "tweakpane": "^4.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "@types/three": "^0.180.0",
+        "typescript": "^5.4.5",
+        "vite": "^5.2.0"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.3.tgz",
+      "integrity": "sha512-h6cqHGZ6VdnwliFG1NXvMPTy/9PS3h8oLh7ImwR+kl+oYnQizgjxsONmmPSb2C66RksfkfIxEVtDSEcJiO0tqw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.3.tgz",
+      "integrity": "sha512-wd+u7SLT/u6knklV/ifG7gr5Qy4GUbH2hMWcDauPFJzmCZUAJ8L2bTkVXC2niOIxp8lk3iH/QX8kSrUxVZrOVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.3.tgz",
+      "integrity": "sha512-lj9ViATR1SsqycwFkJCtYfQTheBdvlWJqzqxwc9f2qrcVrQaF/gCuBRTiTolkRWS6KvNxSk4KHZWG7tDktLgjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.3.tgz",
+      "integrity": "sha512-+Dyo7O1KUmIsbzx1l+4V4tvEVnVQqMOIYtrxK7ncLSknl1xnMHLgn7gddJVrYPNZfEB8CIi3hK8gq8bDhb3h5A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.3.tgz",
+      "integrity": "sha512-u9Xg2FavYbD30g3DSfNhxgNrxhi6xVG4Y6i9Ur1C7xUuGDW3banRbXj+qgnIrwRN4KeJ396jchwy9bCIzbyBEQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.3.tgz",
+      "integrity": "sha512-5M8kyi/OX96wtD5qJR89a/3x5x8x5inXBZO04JWhkQb2JWavOWfjgkdvUqibGJeNNaz1/Z1PPza5/tAPXICI6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.3.tgz",
+      "integrity": "sha512-IoerZJ4l1wRMopEHRKOO16e04iXRDyZFZnNZKrWeNquh5d6bucjezgd+OxG03mOMTnS1x7hilzb3uURPkJ0OfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.3.tgz",
+      "integrity": "sha512-ZYdtqgHTDfvrJHSh3W22TvjWxwOgc3ThK/XjgcNGP2DIwFIPeAPNsQxrJO5XqleSlgDux2VAoWQ5iJrtaC1TbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.3.tgz",
+      "integrity": "sha512-NcViG7A0YtuFDA6xWSgmFb6iPFzHlf5vcqb2p0lGEbT+gjrEEz8nC/EeDHvx6mnGXnGCC1SeVV+8u+smj0CeGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.3.tgz",
+      "integrity": "sha512-d3pY7LWno6SYNXRm6Ebsq0DJGoiLXTb83AIPCXl9fmtIQs/rXoS8SJxxUNtFbJ5MiOvs+7y34np77+9l4nfFMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.3.tgz",
+      "integrity": "sha512-3y5GA0JkBuirLqmjwAKwB0keDlI6JfGYduMlJD/Rl7fvb4Ni8iKdQs1eiunMZJhwDWdCvrcqXRY++VEBbvk6Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.3.tgz",
+      "integrity": "sha512-AUUH65a0p3Q0Yfm5oD2KVgzTKgwPyp9DSXc3UA7DtxhEb/WSPfbG4wqXeSN62OG5gSo18em4xv6dbfcUGXcagw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.3.tgz",
+      "integrity": "sha512-1makPhFFVBqZE+XFg3Dkq+IkQ7JvmUrwwqaYBL2CE+ZpxPaqkGaiWFEWVGyvTwZace6WLJHwjVh/+CXbKDGPmg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.3.tgz",
+      "integrity": "sha512-OOFJa28dxfl8kLOPMUOQBCO6z3X2SAfzIE276fwT52uXDWUS178KWq0pL7d6p1kz7pkzA0yQwtqL0dEPoVcRWg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.3.tgz",
+      "integrity": "sha512-jMdsML2VI5l+V7cKfZx3ak+SLlJ8fKvLJ0Eoa4b9/vCUrzXKgoKxvHqvJ/mkWhFiyp88nCkM5S2v6nIwRtPcgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.3.tgz",
+      "integrity": "sha512-tPgGd6bY2M2LJTA1uGq8fkSPK8ZLYjDjY+ZLK9WHncCnfIz29LIXIqUgzCR0hIefzy6Hpbe8Th5WOSwTM8E7LA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.3.tgz",
+      "integrity": "sha512-BCFkJjgk+WFzP+tcSMXq77ymAPIxsX9lFJWs+2JzuZTLtksJ2o5hvgTdIcZ5+oKzUDMwI0PfWzRBYAydAHF2Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.3.tgz",
+      "integrity": "sha512-KTD/EqjZF3yvRaWUJdD1cW+IQBk4fbQaHYJUmP8N4XoKFZilVL8cobFSTDnjTtxWJQ3JYaMgF4nObY/+nYkumA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.3.tgz",
+      "integrity": "sha512-+zteHZdoUYLkyYKObGHieibUFLbttX2r+58l27XZauq0tcWYYuKUwY2wjeCN9oK1Um2YgH2ibd6cnX/wFD7DuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.3.tgz",
+      "integrity": "sha512-of1iHkTQSo3kr6dTIRX6t81uj/c/b15HXVsPcEElN5sS859qHrOepM5p9G41Hah+CTqSh2r8Bm56dL2z9UQQ7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.3.tgz",
+      "integrity": "sha512-s0hybmlHb56mWVZQj8ra9048/WZTPLILKxcvcq+8awSZmyiSUZjjem1AhU3Tf4ZKpYhK4mg36HtHDOe8QJS5PQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.3.tgz",
+      "integrity": "sha512-zGIbEVVXVtauFgl3MRwGWEN36P5ZGenHRMgNw88X5wEhEBpq0XrMEZwOn07+ICrwM17XO5xfMZqh0OldCH5VTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.23.tgz",
+      "integrity": "sha512-GPe4AsfOSpqWd3xA/0gwoKod13ChcfV67trvxaW2krUbgb9gxQjnCx8zGshzMl8LSHZlNH5gQ8LNScsDuc7nGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.65.tgz",
+      "integrity": "sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
+      "integrity": "sha512-RIDh866U8agLgiIcdpB+COKnlCreHJLfIhWC3LVflku5YHfpnsIKigRZeFfMfCc4dVcqNVfQQ5gO/afOck064A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.3",
+        "@rollup/rollup-android-arm64": "4.52.3",
+        "@rollup/rollup-darwin-arm64": "4.52.3",
+        "@rollup/rollup-darwin-x64": "4.52.3",
+        "@rollup/rollup-freebsd-arm64": "4.52.3",
+        "@rollup/rollup-freebsd-x64": "4.52.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.3",
+        "@rollup/rollup-linux-arm64-musl": "4.52.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.3",
+        "@rollup/rollup-linux-x64-gnu": "4.52.3",
+        "@rollup/rollup-linux-x64-musl": "4.52.3",
+        "@rollup/rollup-openharmony-arm64": "4.52.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.3",
+        "@rollup/rollup-win32-x64-gnu": "4.52.3",
+        "@rollup/rollup-win32-x64-msvc": "4.52.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
+    },
+    "node_modules/tweakpane": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/tweakpane/-/tweakpane-4.0.5.tgz",
+      "integrity": "sha512-rxEXdSI+ArlG1RyO6FghC4ZUX8JkEfz8F3v1JuteXSV0pEtHJzyo07fcDG+NsJfN5L39kSbCYbB9cBGHyuI/tQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/cocopon"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.20",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.20.tgz",
+      "integrity": "sha512-j3lYzGC3P+B5Yfy/pfKNgVEg4+UtcIJcVRt2cDjIOmhLourAqPqf8P7acgxeiSgUB7E3p2P8/3gNIgDLpwzs4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "universal-webgpu-tsl-scaffold",
+  "version": "0.1.0",
+  "description": "Universal WebGPU+TSL scaffold built with Three.js and Vite",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "three": "^0.180.0",
+    "tweakpane": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/three": "^0.180.0",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/CONVAS.ts
+++ b/src/CONVAS.ts
@@ -1,0 +1,239 @@
+import { Clock, Color, Vector2, WebGLRenderer } from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { WebGPURenderer } from 'three/webgpu';
+import { mergeConfig, defaultConfig, type Config, type PartialDeep } from './config';
+import { Stage } from './STAGE/stage';
+import { PostFX } from './POSTFX/postfx';
+import { Dashboard } from './UI/dashboard';
+
+export interface Feature {
+  id: string;
+  attach(app: Convas): void | Promise<void>;
+  detach?(app: Convas): void;
+}
+
+export interface ConvasOptions {
+  config?: PartialDeep<Config>;
+  features?: Feature[];
+  autoStart?: boolean;
+}
+
+type RendererLike = WebGLRenderer | WebGPURenderer;
+
+export class Convas {
+  readonly canvas: HTMLCanvasElement;
+  readonly renderer: RendererLike;
+  readonly config: Config;
+  readonly stage: Stage;
+  readonly postfx: PostFX;
+  readonly dashboard: Dashboard;
+
+  private readonly clock = new Clock();
+  private readonly size = new Vector2(1, 1);
+  private readonly features = new Map<string, Feature>();
+  private readonly tickHandlers = new Set<(delta: number, elapsed: number) => void>();
+  private controls?: OrbitControls;
+  private raf?: number;
+  private resizeObserver?: ResizeObserver;
+
+  constructor(canvas: HTMLCanvasElement, options: ConvasOptions = {}) {
+    this.canvas = canvas;
+    this.config = mergeConfig(defaultConfig, options.config);
+    this.renderer = this.createRenderer(canvas, this.config);
+    this.stage = new Stage(this.renderer, this.config);
+    this.postfx = new PostFX(this.renderer, this.stage.scene, this.stage.camera, this.measureCanvas(), this.config.postfx);
+    this.dashboard = new Dashboard(this.config.dashboard);
+    this.setupDashboard();
+
+    this.configureRenderer();
+    this.configureControls();
+    this.observeResize();
+
+    if (options.features) {
+      options.features.forEach(feature => {
+        this.attachFeature(feature).catch(err => console.error('[CONVAS] Feature attach failed', err));
+      });
+    }
+
+    if (options.autoStart ?? true) {
+      this.start();
+    }
+  }
+
+  private configureRenderer(): void {
+    const pixelRatio = Math.min(window.devicePixelRatio, 2);
+    this.renderer.setPixelRatio(pixelRatio);
+    this.renderer.setSize(this.size.x, this.size.y, false);
+    (this.renderer as any).toneMapping = this.config.renderer.toneMapping;
+    (this.renderer as any).outputColorSpace = this.config.renderer.colorSpace;
+    if ('toneMappingExposure' in this.renderer) {
+      (this.renderer as any).toneMappingExposure = this.config.renderer.exposure;
+    }
+    if ('setClearColor' in this.renderer) {
+      (this.renderer as any).setClearColor(new Color(this.config.stage.background));
+    }
+    if ('shadowMap' in this.renderer) {
+      (this.renderer as WebGLRenderer).shadowMap.enabled = true;
+    }
+    if (this.renderer instanceof WebGPURenderer) {
+      this.renderer.init().catch((err: unknown) => console.warn('WebGPU init failed, falling back to WebGL', err));
+    }
+  }
+
+  private configureControls(): void {
+    this.controls = new OrbitControls(this.stage.camera, this.canvas);
+    this.controls.target.fromArray(this.config.camera.target);
+    this.controls.enableDamping = true;
+  }
+
+  private observeResize(): void {
+    this.resizeObserver = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        if (entry.target !== this.canvas) continue;
+        const { width, height } = entry.contentRect;
+        this.resize(width, height);
+      }
+    });
+    this.resizeObserver.observe(this.canvas);
+    const rect = this.canvas.getBoundingClientRect();
+    this.resize(rect.width || 1, rect.height || 1);
+  }
+
+  private createRenderer(canvas: HTMLCanvasElement, config: Config): RendererLike {
+    const prefersWebGPU = config.renderer.useWebGPU && WebGPURenderer.isAvailable();
+    if (prefersWebGPU) {
+      try {
+        return new WebGPURenderer({ canvas, antialias: config.renderer.antialias });
+      } catch (err) {
+        console.warn('[CONVAS] WebGPU renderer creation failed, falling back to WebGL.', err);
+      }
+    }
+    const renderer = new WebGLRenderer({ canvas, antialias: config.renderer.antialias });
+    (renderer as any).physicallyCorrectLights = true;
+    (renderer as any).outputColorSpace = config.renderer.colorSpace;
+    (renderer as any).toneMapping = config.renderer.toneMapping;
+    renderer.toneMappingExposure = config.renderer.exposure;
+    return renderer;
+  }
+
+  private measureCanvas(): { width: number; height: number } {
+    const rect = this.canvas.getBoundingClientRect();
+    const width = rect.width || this.canvas.width || 1;
+    const height = rect.height || this.canvas.height || 1;
+    this.size.set(width, height);
+    return { width, height };
+  }
+
+  private setupDashboard(): void {
+    this.dashboard.section('renderer', {
+      title: 'Renderer',
+      params: {
+        exposure: {
+          value: this.config.renderer.exposure,
+          min: 0.1,
+          max: 4,
+          step: 0.01,
+          label: 'Exposure'
+        }
+      },
+      onChange: (key, value) => {
+        if (key === 'exposure') {
+          this.config.renderer.exposure = value as number;
+          if (this.renderer instanceof WebGLRenderer) {
+            this.renderer.toneMappingExposure = this.config.renderer.exposure;
+          } else {
+            (this.renderer as WebGPURenderer).toneMappingExposure = this.config.renderer.exposure;
+          }
+        }
+      }
+    });
+
+    this.dashboard.section('lights', {
+      title: 'Lights',
+      params: {
+        key: { value: this.config.lights.keyIntensity, min: 0, max: 5, step: 0.05, label: 'Key' },
+        fill: { value: this.config.lights.fillIntensity, min: 0, max: 5, step: 0.05, label: 'Fill' },
+        rim: { value: this.config.lights.rimIntensity, min: 0, max: 5, step: 0.05, label: 'Rim' }
+      },
+      onChange: (key, value) => {
+        const light = this.stage.lightRig.getObjectByName(key);
+        if (light) {
+          (light as any).intensity = value;
+        }
+      }
+    });
+
+    this.dashboard.section('postfx', {
+      title: 'PostFX',
+      params: {
+        bloom: { value: this.config.postfx.bloom.strength, min: 0, max: 2, step: 0.01, label: 'Bloom' },
+        dof: { value: this.config.postfx.dof.aperture, min: 0, max: 0.1, step: 0.001, label: 'DOF Aperture' },
+        focus: { value: this.config.postfx.dof.focus, min: 0.1, max: 5, step: 0.01, label: 'Focus' }
+      },
+      onChange: (key, value) => {
+        if (key === 'bloom') this.config.postfx.bloom.strength = value as number;
+        if (key === 'dof') this.config.postfx.dof.aperture = value as number;
+        if (key === 'focus') this.config.postfx.dof.focus = value as number;
+        this.postfx.update(this.config.postfx);
+      }
+    });
+  }
+
+  private render = (): void => {
+    const delta = this.clock.getDelta();
+    const elapsed = this.clock.elapsedTime;
+    this.controls?.update();
+    this.tickHandlers.forEach(handler => handler(delta, elapsed));
+    this.postfx.render(delta);
+    this.raf = requestAnimationFrame(this.render);
+  };
+
+  start(): void {
+    if (this.raf != null) return;
+    this.clock.start();
+    this.raf = requestAnimationFrame(this.render);
+  }
+
+  stop(): void {
+    if (this.raf == null) return;
+    cancelAnimationFrame(this.raf);
+    this.raf = undefined;
+  }
+
+  resize(width: number, height: number): void {
+    if (!width || !height) return;
+    this.size.set(width, height);
+    this.stage.resize({ width, height });
+    this.renderer.setSize(width, height, false);
+    this.postfx.setSize(width, height);
+  }
+
+  async attachFeature(feature: Feature): Promise<void> {
+    if (this.features.has(feature.id)) return;
+    this.features.set(feature.id, feature);
+    await feature.attach(this);
+  }
+
+  detachFeature(id: string): void {
+    const feature = this.features.get(id);
+    if (!feature) return;
+    feature.detach?.(this);
+    this.features.delete(id);
+  }
+
+  onTick(handler: (delta: number, elapsed: number) => void): () => void {
+    this.tickHandlers.add(handler);
+    return () => this.tickHandlers.delete(handler);
+  }
+
+  dispose(): void {
+    this.stop();
+    this.controls?.dispose();
+    this.resizeObserver?.disconnect();
+    this.dashboard.dispose();
+    this.stage.dispose();
+    this.features.forEach(feature => feature.detach?.(this));
+    this.features.clear();
+    this.tickHandlers.clear();
+  }
+}

--- a/src/POSTFX/postfx.ts
+++ b/src/POSTFX/postfx.ts
@@ -1,0 +1,106 @@
+import {
+  PerspectiveCamera,
+  Scene,
+  Vector2,
+  WebGLRenderer
+} from 'three';
+import type { WebGPURenderer } from 'three/webgpu';
+import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js';
+import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
+import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
+import { BokehPass } from 'three/examples/jsm/postprocessing/BokehPass.js';
+import { FilmPass } from 'three/examples/jsm/postprocessing/FilmPass.js';
+import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+import { VignetteShader } from 'three/examples/jsm/shaders/VignetteShader.js';
+import type { Config } from '../config';
+
+export type RendererLike = WebGLRenderer | WebGPURenderer;
+
+export class PostFX {
+  private readonly renderer: RendererLike;
+  private config: Config['postfx'];
+  private readonly scene: Scene;
+  private readonly camera: PerspectiveCamera;
+  private composer?: EffectComposer;
+  private readonly size = new Vector2();
+  private bloomPass?: UnrealBloomPass;
+  private dofPass?: BokehPass;
+  private vignettePass?: ShaderPass;
+  private grainPass?: FilmPass;
+
+  constructor(
+    renderer: RendererLike,
+    scene: Scene,
+    camera: PerspectiveCamera,
+    size: { width: number; height: number },
+    config: Config['postfx']
+  ) {
+    this.renderer = renderer;
+    this.config = config;
+    this.scene = scene;
+    this.camera = camera;
+    this.size.set(size.width, size.height);
+
+    if (renderer instanceof WebGLRenderer && config.enabled) {
+      this.composer = new EffectComposer(renderer);
+      this.composer.addPass(new RenderPass(scene, camera));
+
+      this.bloomPass = new UnrealBloomPass(this.size.clone(), config.bloom.strength, config.bloom.radius, config.bloom.threshold);
+      this.composer.addPass(this.bloomPass);
+
+      this.dofPass = new BokehPass(scene, camera, {
+        focus: config.dof.focus,
+        aperture: config.dof.aperture,
+        maxblur: config.dof.maxBlur
+      });
+      this.composer.addPass(this.dofPass);
+
+      this.vignettePass = new ShaderPass(VignetteShader);
+      this.vignettePass.uniforms['offset'].value = 1.0 - config.vignette * 0.5;
+      this.vignettePass.uniforms['darkness'].value = 1.0 + config.vignette;
+      this.composer.addPass(this.vignettePass);
+
+      this.grainPass = new FilmPass();
+      (this.grainPass.uniforms as Record<string, { value: number }>).nIntensity.value = config.grain * 2.5;
+      this.composer.addPass(this.grainPass);
+
+      this.setSize(size.width, size.height);
+    }
+  }
+
+  update(config: Config['postfx']): void {
+    this.config = config;
+    if (this.bloomPass) {
+      this.bloomPass.threshold = config.bloom.threshold;
+      this.bloomPass.strength = config.bloom.strength;
+      this.bloomPass.radius = config.bloom.radius;
+    }
+    if (this.dofPass) {
+      this.dofPass.materialBokeh.uniforms['focus'].value = config.dof.focus;
+      this.dofPass.materialBokeh.uniforms['aperture'].value = config.dof.aperture;
+      this.dofPass.materialBokeh.uniforms['maxblur'].value = config.dof.maxBlur;
+    }
+    if (this.vignettePass) {
+      this.vignettePass.uniforms['offset'].value = 1.0 - config.vignette * 0.5;
+      this.vignettePass.uniforms['darkness'].value = 1.0 + config.vignette;
+    }
+    if (this.grainPass) {
+      (this.grainPass.uniforms as Record<string, { value: number }>).nIntensity.value = config.grain * 2.5;
+    }
+  }
+
+  setSize(width: number, height: number): void {
+    this.size.set(width, height);
+    if (this.composer) {
+      this.composer.setSize(width, height);
+    }
+  }
+
+  render(delta: number): void {
+    if (this.composer) {
+      this.composer.render(delta);
+    } else if ('render' in this.renderer) {
+      (this.renderer as WebGLRenderer | WebGPURenderer).render(this.scene, this.camera);
+    }
+  }
+}

--- a/src/STAGE/camera.ts
+++ b/src/STAGE/camera.ts
@@ -1,0 +1,23 @@
+import { PerspectiveCamera, Vector3 } from 'three';
+import type { CameraConfig } from '../config';
+
+export class CameraRig {
+  readonly camera: PerspectiveCamera;
+  readonly target: Vector3;
+
+  constructor(config: CameraConfig) {
+    this.camera = new PerspectiveCamera(config.fov, 1, config.near, config.far);
+    this.camera.position.fromArray(config.position);
+    this.target = new Vector3().fromArray(config.target);
+    this.lookAtTarget();
+  }
+
+  lookAtTarget(): void {
+    this.camera.lookAt(this.target);
+  }
+
+  resize(width: number, height: number): void {
+    this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+  }
+}

--- a/src/STAGE/light.ts
+++ b/src/STAGE/light.ts
@@ -1,0 +1,32 @@
+import {
+  AmbientLight,
+  Color,
+  DirectionalLight,
+  Group
+} from 'three';
+import type { LightConfig } from '../config';
+
+export class LightRig extends Group {
+  constructor(config: LightConfig) {
+    super();
+
+    const color = new Color(config.color);
+    const ambient = new AmbientLight(color, config.fillIntensity * 0.5);
+    ambient.name = 'ambient';
+
+    const key = new DirectionalLight(color, config.keyIntensity);
+    key.position.set(5, 6, 4);
+    key.castShadow = true;
+    key.name = 'key';
+
+    const fill = new DirectionalLight(color, config.fillIntensity);
+    fill.position.set(-4, 3, -3);
+    fill.name = 'fill';
+
+    const rim = new DirectionalLight(color, config.rimIntensity);
+    rim.position.set(-1, 5, 5);
+    rim.name = 'rim';
+
+    this.add(ambient, key, fill, rim);
+  }
+}

--- a/src/STAGE/stage.ts
+++ b/src/STAGE/stage.ts
@@ -1,0 +1,92 @@
+import {
+  AxesHelper,
+  Color,
+  GridHelper,
+  Mesh,
+  MeshStandardMaterial,
+  Object3D,
+  PlaneGeometry,
+  PMREMGenerator,
+  Scene,
+  Texture,
+  WebGLRenderer
+} from 'three';
+import { RoomEnvironment } from 'three/examples/jsm/environments/RoomEnvironment.js';
+import type { WebGPURenderer } from 'three/webgpu';
+import type { Config } from '../config';
+import { CameraRig } from './camera';
+import { LightRig } from './light';
+
+export type RendererLike = WebGLRenderer | WebGPURenderer;
+
+export class Stage {
+  readonly scene: Scene;
+  readonly camera: CameraRig['camera'];
+  readonly cameraRig: CameraRig;
+  readonly lightRig: LightRig;
+  private readonly ground: Mesh;
+  private env?: Texture;
+  private pmrem?: PMREMGenerator;
+
+  constructor(
+    renderer: RendererLike,
+    config: Config
+  ) {
+    this.scene = new Scene();
+    this.scene.background = new Color(config.stage.background);
+    (this.scene as any).environmentIntensity = config.lights.envMapIntensity;
+
+    this.cameraRig = new CameraRig(config.camera);
+    this.camera = this.cameraRig.camera;
+
+    this.lightRig = new LightRig(config.lights);
+    this.scene.add(this.lightRig);
+
+    const grid = new GridHelper(config.stage.gridSize, config.stage.gridDivisions, 0x222222, 0x111111);
+    grid.position.y = 0.001;
+    this.scene.add(grid);
+
+    const axes = new AxesHelper(1.5);
+    axes.position.y = 0.002;
+    this.scene.add(axes);
+
+    const groundGeo = new PlaneGeometry(config.stage.gridSize, config.stage.gridSize);
+    const groundMat = new MeshStandardMaterial({
+      color: new Color(config.stage.background).multiplyScalar(1.1),
+      roughness: 0.9,
+      metalness: 0
+    });
+    this.ground = new Mesh(groundGeo, groundMat);
+    this.ground.rotation.x = -Math.PI / 2;
+    this.ground.receiveShadow = true;
+    this.scene.add(this.ground);
+
+    if (renderer instanceof WebGLRenderer) {
+      this.pmrem = new PMREMGenerator(renderer);
+      this.env = this.pmrem.fromScene(new RoomEnvironment(), 0.1).texture;
+      this.scene.environment = this.env;
+      this.scene.background = this.scene.background ?? new Color('#000000');
+    }
+  }
+
+  add(node: Object3D): void {
+    this.scene.add(node);
+  }
+
+  remove(node: Object3D): void {
+    this.scene.remove(node);
+  }
+
+  resize(size: { width: number; height: number }): void {
+    this.cameraRig.resize(size.width, size.height);
+  }
+
+  dispose(): void {
+    this.ground.geometry.dispose();
+    (this.ground.material as MeshStandardMaterial).dispose();
+    if (this.env) {
+      this.env.dispose();
+    }
+    this.pmrem?.dispose();
+  }
+}

--- a/src/UI/dashboard.ts
+++ b/src/UI/dashboard.ts
@@ -1,0 +1,64 @@
+import { Pane, type FolderApi, type TpChangeEvent } from 'tweakpane';
+import type { Config } from '../config';
+import { ensureDashboardStyles } from './panels';
+
+export interface SectionParam {
+  value: number | string | boolean;
+  label?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  options?: Record<string, number | string | boolean>;
+}
+
+export interface SectionSpec {
+  title: string;
+  params: Record<string, SectionParam>;
+  onChange?: (key: string, value: SectionParam['value']) => void;
+}
+
+export class Dashboard {
+  private readonly pane: Pane;
+  private readonly sections = new Map<string, FolderApi>();
+
+  constructor(config: Config['dashboard']) {
+    ensureDashboardStyles();
+    this.pane = new Pane({
+      title: 'Scaffold Dashboard',
+      expanded: config.expanded
+    });
+    this.pane.element.classList.add('convas-dashboard');
+  }
+
+  section(id: string, spec: SectionSpec): void {
+    if (this.sections.has(id)) {
+      const folder = this.sections.get(id)!;
+      folder.dispose();
+      this.sections.delete(id);
+    }
+
+    const paneAsFolder = this.pane as unknown as FolderApi;
+    const folder = paneAsFolder.addFolder({ title: spec.title, expanded: true });
+    this.sections.set(id, folder);
+
+    Object.entries(spec.params).forEach(([key, param]) => {
+      const params = { [key]: param.value };
+      const binding = folder.addBinding(params, key, {
+        label: param.label ?? key,
+        min: param.min,
+        max: param.max,
+        step: param.step,
+        options: param.options
+      });
+      binding.on('change', (ev: TpChangeEvent<SectionParam['value']>) => {
+        if (!spec.onChange) return;
+        spec.onChange(key, ev.value as SectionParam['value']);
+      });
+    });
+  }
+
+  dispose(): void {
+    this.sections.clear();
+    this.pane.dispose();
+  }
+}

--- a/src/UI/panels.ts
+++ b/src/UI/panels.ts
@@ -1,0 +1,33 @@
+const STYLE_ID = 'convas-dashboard-style';
+
+export function ensureDashboardStyles(): void {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = `
+    .tp-dfwv {
+      backdrop-filter: blur(16px) saturate(140%);
+      background: rgba(22, 24, 33, 0.65);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+      border-radius: 16px;
+      color: #e6e8ef;
+    }
+    .tp-rotv * {
+      color: inherit !important;
+    }
+    .tp-lblv_v {
+      color: rgba(230, 232, 239, 0.72) !important;
+    }
+    .tp-rotv::-webkit-scrollbar {
+      width: 8px;
+    }
+    .tp-rotv::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.08);
+      border-radius: 99px;
+    }
+  `;
+  document.head.append(style);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,146 @@
+import { ACESFilmicToneMapping, LinearSRGBColorSpace } from 'three';
+
+type Primitive = string | number | boolean | undefined | null;
+
+export type PartialDeep<T> = {
+  [K in keyof T]?: T[K] extends Primitive
+    ? T[K]
+    : T[K] extends Array<infer V>
+      ? Array<PartialDeep<V>>
+      : PartialDeep<T[K]>;
+};
+
+export interface RendererConfig {
+  exposure: number;
+  toneMapping: number;
+  colorSpace: string;
+  antialias: boolean;
+  useWebGPU: boolean;
+}
+
+export interface CameraConfig {
+  fov: number;
+  near: number;
+  far: number;
+  position: [number, number, number];
+  target: [number, number, number];
+}
+
+export interface LightConfig {
+  envMapIntensity: number;
+  keyIntensity: number;
+  fillIntensity: number;
+  rimIntensity: number;
+  color: string;
+}
+
+export interface StageConfig {
+  background: string;
+  gridSize: number;
+  gridDivisions: number;
+}
+
+export interface BloomConfig {
+  strength: number;
+  radius: number;
+  threshold: number;
+}
+
+export interface DofConfig {
+  focus: number;
+  aperture: number;
+  maxBlur: number;
+}
+
+export interface PostFXConfig {
+  enabled: boolean;
+  bloom: BloomConfig;
+  dof: DofConfig;
+  vignette: number;
+  grain: number;
+}
+
+export interface DashboardConfig {
+  expanded: boolean;
+}
+
+export interface Config {
+  renderer: RendererConfig;
+  camera: CameraConfig;
+  lights: LightConfig;
+  stage: StageConfig;
+  postfx: PostFXConfig;
+  dashboard: DashboardConfig;
+}
+
+export const defaultConfig: Config = {
+  renderer: {
+    exposure: 1.0,
+    toneMapping: ACESFilmicToneMapping,
+    colorSpace: LinearSRGBColorSpace,
+    antialias: true,
+    useWebGPU: true
+  },
+  camera: {
+    fov: 45,
+    near: 0.1,
+    far: 200,
+    position: [3, 2, 5],
+    target: [0, 1, 0]
+  },
+  lights: {
+    envMapIntensity: 1.5,
+    keyIntensity: 2.5,
+    fillIntensity: 1.1,
+    rimIntensity: 1.8,
+    color: '#ffffff'
+  },
+  stage: {
+    background: '#0b0d11',
+    gridSize: 20,
+    gridDivisions: 40
+  },
+  postfx: {
+    enabled: true,
+    bloom: {
+      strength: 0.9,
+      radius: 0.45,
+      threshold: 0.4
+    },
+    dof: {
+      focus: 1.2,
+      aperture: 0.025,
+      maxBlur: 0.01
+    },
+    vignette: 0.25,
+    grain: 0.35
+  },
+  dashboard: {
+    expanded: true
+  }
+};
+
+function clone<T>(value: T): T {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function mergeConfig<T>(base: T, patch?: PartialDeep<T>): T {
+  const result: any = clone(base);
+  if (!patch) return result;
+  for (const key of Object.keys(patch) as Array<keyof T>) {
+    const value = patch[key];
+    if (value === undefined) continue;
+    const baseValue = result[key];
+    if (Array.isArray(baseValue) && Array.isArray(value)) {
+      result[key] = value.slice();
+    } else if (baseValue && typeof baseValue === 'object' && value && typeof value === 'object') {
+      result[key] = mergeConfig(baseValue, value as any);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,5 @@
+export { Convas, type ConvasOptions, type Feature } from './CONVAS';
+export { defaultConfig, mergeConfig, type Config, type PartialDeep } from './config';
+export { Stage } from './STAGE/stage';
+export { PostFX } from './POSTFX/postfx';
+export { Dashboard } from './UI/dashboard';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,160 @@
+import {
+  BufferGeometry,
+  Color,
+  DoubleSide,
+  Float32BufferAttribute,
+  Group,
+  MathUtils,
+  Mesh,
+  MeshPhysicalMaterial,
+  Points,
+  PointsMaterial,
+  SphereGeometry,
+  TorusGeometry,
+  TorusKnotGeometry
+} from 'three';
+import MeshPhysicalNodeMaterial from 'three/src/materials/nodes/MeshPhysicalNodeMaterial.js';
+import { Convas } from './CONVAS';
+
+const canvas = document.querySelector('#app');
+if (!(canvas instanceof HTMLCanvasElement)) {
+  throw new Error('Canvas element with id "app" not found.');
+}
+
+const app = new Convas(canvas, {
+  config: {
+    renderer: { exposure: 1.3 },
+    camera: { position: [5, 2.8, 7], target: [0, 1.2, 0] },
+    postfx: {
+      enabled: true,
+      bloom: { strength: 0.85, radius: 0.4, threshold: 0.45 },
+      dof: { focus: 1.4, aperture: 0.018, maxBlur: 0.008 },
+      vignette: 0.3,
+      grain: 0.28
+    }
+  }
+});
+
+const sculpture = createSculpture();
+const halo = createHaloParticles();
+
+app.stage.add(sculpture);
+app.stage.add(halo);
+
+let spinEnabled = true;
+const disposeSpin = app.onTick((delta, elapsed) => {
+  if (!spinEnabled) return;
+  sculpture.rotation.y += delta * 0.5;
+  sculpture.rotation.x = Math.sin(elapsed * 0.35) * 0.2;
+  halo.rotation.y -= delta * 0.2;
+  halo.children.forEach((child, index) => {
+    child.position.y = 1.5 + Math.sin(elapsed * 0.6 + index) * 0.35;
+    child.rotation.y += delta * 0.4;
+  });
+});
+
+app.dashboard.section('demo', {
+  title: 'Demo Scene',
+  params: {
+    spin: { value: spinEnabled, label: 'Animate' }
+  },
+  onChange: (key, value) => {
+    if (key === 'spin') {
+      spinEnabled = Boolean(value);
+    }
+  }
+});
+
+window.addEventListener('beforeunload', () => {
+  disposeSpin();
+});
+
+Object.assign(window, { app });
+
+function createSculpture(): Group {
+  const group = new Group();
+
+  const glassMaterial = new MeshPhysicalNodeMaterial({
+    metalness: 0.05,
+    roughness: 0.04,
+    transmission: 0.96,
+    thickness: 1.6,
+    attenuationColor: new Color('#6ea5ff'),
+    attenuationDistance: 1.2,
+    iridescence: 1,
+    iridescenceIOR: 1.25,
+    iridescenceThicknessRange: [140, 420]
+  });
+  glassMaterial.side = DoubleSide;
+
+  const glassCore = new Mesh(new SphereGeometry(1.1, 96, 96), glassMaterial);
+  glassCore.castShadow = true;
+  glassCore.position.y = 1.2;
+  group.add(glassCore);
+
+  const brushedMetal = new MeshPhysicalMaterial({
+    color: new Color('#f4c49a'),
+    metalness: 0.75,
+    roughness: 0.22,
+    clearcoat: 0.8,
+    clearcoatRoughness: 0.18
+  });
+
+  const ribbon = new Mesh(new TorusKnotGeometry(0.7, 0.18, 220, 32), brushedMetal);
+  ribbon.position.set(-1.8, 1.2, 0);
+  ribbon.castShadow = true;
+  group.add(ribbon);
+
+  const ring = new Mesh(new TorusGeometry(1.4, 0.05, 32, 128), brushedMetal.clone());
+  ring.position.set(1.75, 1.2, 0);
+  ring.rotation.x = MathUtils.degToRad(70);
+  ring.rotation.z = MathUtils.degToRad(30);
+  group.add(ring);
+
+  return group;
+}
+
+function createHaloParticles(): Group {
+  const group = new Group();
+  const count = 200;
+  const radius = 2.2;
+
+  const geometry = new BufferGeometry();
+  const positions: number[] = [];
+  for (let i = 0; i < count; i++) {
+    const angle = (i / count) * Math.PI * 2;
+    const offset = MathUtils.randFloatSpread(0.35);
+    const x = Math.cos(angle) * (radius + offset);
+    const z = Math.sin(angle) * (radius + offset);
+    const y = 1.5 + MathUtils.randFloatSpread(0.35);
+    positions.push(x, y, z);
+  }
+  geometry.setAttribute('position', new Float32BufferAttribute(positions, 3));
+
+  const material = new PointsMaterial({
+    size: 0.05,
+    color: new Color('#a8c6ff'),
+    transparent: true,
+    opacity: 0.85
+  });
+
+  const points = new Points(geometry, material);
+  group.add(points);
+
+  for (let i = 0; i < 3; i++) {
+    const pod = new Mesh(
+      new TorusGeometry(0.25, 0.04, 24, 48),
+      new MeshPhysicalMaterial({
+        color: new Color('#8fb0ff'),
+        metalness: 0.25,
+        roughness: 0.35,
+        transmission: 0.6,
+        thickness: 0.4
+      })
+    );
+    pod.position.set(Math.cos(i) * 2.1, 1.5, Math.sin(i) * 2.1);
+    group.add(pod);
+  }
+
+  return group;
+}

--- a/src/types/three-augmentations.d.ts
+++ b/src/types/three-augmentations.d.ts
@@ -1,0 +1,17 @@
+declare module 'three/webgpu' {
+  import { WebGLRenderer, WebGLRendererParameters } from 'three';
+
+  export class WebGPURenderer extends WebGLRenderer {
+    constructor(parameters?: WebGLRendererParameters);
+    static isAvailable(): boolean;
+    init(): Promise<void>;
+  }
+}
+
+declare module 'three/src/materials/nodes/MeshPhysicalNodeMaterial.js' {
+  import { MeshPhysicalMaterial, MeshPhysicalMaterialParameters } from 'three';
+
+  export default class MeshPhysicalNodeMaterial extends MeshPhysicalMaterial {
+    constructor(parameters?: MeshPhysicalMaterialParameters);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2021", "DOM"],
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"],
+    "noEmit": true
+  },
+  "include": ["src/**/*", "vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+  server: {
+    host: true
+  }
+});


### PR DESCRIPTION
## Summary
- add a styled root `index.html` and README notes so the Vite preview build serves the WebGPU demo scene
- enhance the Convas/PostFX runtime with WebGPU fallback handling, animation hooks, and supporting type declarations while expanding the animated sample scene
- add `@types/three`, enable `tsc` no-emit checks, and ignore build/node_modules artifacts for cleaner tooling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da295602a88327b9801fa7bfeec440